### PR TITLE
fix(sharePanel): #FOR-516 add onFailure function on directive to handle custom user error log

### DIFF
--- a/src/ts/directives/sharePanel.ts
+++ b/src/ts/directives/sharePanel.ts
@@ -61,7 +61,7 @@ export interface SharePanelScope {
     closeDelegate?(args: ShareCloseDelegate)
     onCancel?()
     onSubmit?(args: { $shared: SharePayload })
-    onFailure?(args: { $error : any})
+    onFailure?(args: { $error : JQueryXHR})
     onFeed?(args: {
         $data: SharePayload,
         $resource: ShareableWithId,

--- a/src/ts/directives/sharePanel.ts
+++ b/src/ts/directives/sharePanel.ts
@@ -61,6 +61,7 @@ export interface SharePanelScope {
     closeDelegate?(args: ShareCloseDelegate)
     onCancel?()
     onSubmit?(args: { $shared: SharePayload })
+    onFailure?(args: { $error : any})
     onFeed?(args: {
         $data: SharePayload,
         $resource: ShareableWithId,
@@ -95,6 +96,7 @@ export const sharePanel = ng.directive('sharePanel', ['$rootScope', ($rootScope)
             onCancel: '&?',
             onSubmit: '&?',
             onValidate: '&?',
+            onFailure: '&?',
             onFeed: '&?',
             closeDelegate: '&?',
             confirmationCloseDelegate: '&?',
@@ -598,7 +600,6 @@ export const sharePanel = ng.directive('sharePanel', ['$rootScope', ($rootScope)
 
             $scope.share = async function () {
                 $scope.sharingModel.changed = false;
-
                 const data: SharePayload = {};
                 const users: { [key: string]: string[] } = {};
                 const groups: { [key: string]: string[] } = {};
@@ -660,8 +661,8 @@ export const sharePanel = ng.directive('sharePanel', ['$rootScope', ($rootScope)
                                 $rootScope.$broadcast('share-updated', res['notify-timeline-array']);
                                 resolve()
                             })
-                            .error(function () {
-                                reject()
+                            .error(function (e) {
+                                reject(e)
                             });
                     })
                 });
@@ -669,7 +670,7 @@ export const sharePanel = ng.directive('sharePanel', ['$rootScope', ($rootScope)
                     await Promise.all(promises);
                     notify.success('share.notify.success');
                 } catch (e) {
-                    notify.error('share.notify.error');
+                   $attributes.onFailure ? $scope.onFailure( {'$error' : e} ) : notify.error('share.notify.error');
                 }
                 if ($scope.autoClose) {
                     await $scope.closePanel(false);


### PR DESCRIPTION
## Describe your changes
We created a function called **onFailure()** which aims to get the error of the catch section. This function can be passed in props on the directive when invoking the share panel in our module. Then we can handle the "custom" error in our front as we want.
Before that, the catch section of infra-front directive sent directly a main notify error. We added a condition to check whether the function is present in props which means that a custom error will be handled. If it's the case, then we get our error back to handle it in a custom way and don't let the main error to be displayed.


Here is the way to handle error on your module :
```
<share-panel on-failure="fonction($error)">
```
Don't forget to put the $error parameter .
## Checklist tests
Compile the infra front on your local environement.
In springboard ent-core.json, set the "max-users-sharing" to 0 (in formulaire config), then try to share a form to someone. A warning must appear.
## Issue ticket number and link
[FOR-516](https://jira.support-ent.fr/browse/FOR-516)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)